### PR TITLE
Build on freebsd

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,11 @@
         '<!(node -e "require(\'nan\')")'
       ],
       'conditions': [
+        ['OS=="freebsd"', {
+          'include_dirs': [
+              '/usr/local/include'
+          ],
+        }],
         ['OS=="mac"', {
           'include_dirs': [
               '/opt/local/include'


### PR DESCRIPTION
> Hi,
> 
> I got this email address from the commit log of node-stringprep-icu.
> 
> I'm wondering if you would be interested in accepted this attached diff which
> makes the module build on FreeBSD, where ICU is installed in /usr/local by
> default, which is not in the path.
> 
> Let me know if you like me to change anything.
> 
> Thanks in advance,
> ## 
> 
> Ashish SHUKLA
